### PR TITLE
Add responsive video template

### DIFF
--- a/newsreader/single.php
+++ b/newsreader/single.php
@@ -19,31 +19,37 @@ get_header(); ?>
 	?>
 
 	<?php
-	while ( have_posts() ) :
-		the_post();
-		?>
+        while ( have_posts() ) :
+                the_post();
+                ?>
 
-		<?php
-		/**
-		 * The csco_post_before hook.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'csco_post_before' );
-		?>
+                <?php
+                /**
+                 * The csco_post_before hook.
+                 *
+                 * @since 1.0.0
+                 */
+                do_action( 'csco_post_before' );
+                ?>
 
-			<?php get_template_part( 'template-parts/content-singular' ); ?>
+                        <?php
+                        if ( has_post_format( 'video' ) ) {
+                                get_template_part( 'template-parts/content', 'video' );
+                        } else {
+                                get_template_part( 'template-parts/content-singular' );
+                        }
+                        ?>
 
-		<?php
-		/**
-		 * The csco_post_after hook.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'csco_post_after' );
-		?>
+                <?php
+                /**
+                 * The csco_post_after hook.
+                 *
+                 * @since 1.0.0
+                 */
+                do_action( 'csco_post_after' );
+                ?>
 
-	<?php endwhile; ?>
+        <?php endwhile; ?>
 
 	<?php
 	/**

--- a/newsreader/style.css
+++ b/newsreader/style.css
@@ -1715,8 +1715,25 @@ table thead td,
 .entry-content iframe,
 .entry-content object,
 .entry-content embed {
-	max-width: 100%;
-	overflow: hidden;
+        max-width: 100%;
+        overflow: hidden;
+}
+
+.entry-video-wrapper {
+        position: relative;
+        width: 100%;
+        padding-top: 56.25%;
+        margin-bottom: 1.5rem;
+}
+.entry-video-wrapper iframe,
+.entry-video-wrapper video,
+.entry-video-wrapper embed,
+.entry-video-wrapper object {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
 }
 
 .alignnone {

--- a/newsreader/template-parts/content-video.php
+++ b/newsreader/template-parts/content-video.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Template part for displaying video posts.
+ *
+ * @package Newsreader
+ */
+
+?>
+
+<div class="cs-entry__wrap">
+
+        <?php
+        /**
+         * The csco_entry_wrap_start hook.
+         *
+         * @since 1.0.0
+         */
+        do_action( 'csco_entry_wrap_start' );
+        ?>
+
+        <div class="cs-entry__container">
+
+                <?php
+                /**
+                 * The csco_entry_container_start hook.
+                 *
+                 * @since 1.0.0
+                 */
+                do_action( 'csco_entry_container_start' );
+                ?>
+
+                <?php
+                $media = get_media_embedded_in_content(
+                        apply_filters( 'the_content', get_the_content() ),
+                        array( 'video', 'object', 'embed', 'iframe' )
+                );
+
+                if ( ! empty( $media ) ) {
+                        echo '<div class="entry-video-wrapper">' . $media[0] . '</div>';
+                }
+
+                // Remove first video from content to avoid duplication.
+                $content = get_the_content();
+                if ( ! empty( $media ) ) {
+                        $content = str_replace( $media[0], '', $content );
+                }
+                ?>
+
+                <div class="cs-entry__content-wrap">
+                        <?php
+                        /**
+                         * The csco_entry_content_before hook.
+                         *
+                         * @since 1.0.0
+                         */
+                        do_action( 'csco_entry_content_before' );
+                        ?>
+
+                        <div class="entry-content">
+                                <?php echo apply_filters( 'the_content', $content ); ?>
+                        </div>
+
+                        <?php
+                        /**
+                         * The csco_entry_content_after hook.
+                         *
+                         * @since 1.0.0
+                         */
+                        do_action( 'csco_entry_content_after' );
+                        ?>
+                </div>
+
+                <?php
+                /**
+                 * The csco_entry_container_end hook.
+                 *
+                 * @since 1.0.0
+                 */
+                do_action( 'csco_entry_container_end' );
+                ?>
+
+        </div>
+
+        <?php
+        /**
+         * The csco_entry_wrap_end hook.
+         *
+         * @since 1.0.0
+         */
+        do_action( 'csco_entry_wrap_end' );
+        ?>
+</div>
+


### PR DESCRIPTION
## Summary
- render video posts with dedicated template and responsive container
- load new template for video post format
- add CSS for responsive embedded videos

## Testing
- `php -l single.php`
- `php -l template-parts/content-video.php`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1aac2b8833089edf210cf633f87