### PR TITLE
Add video-focused styling overrides for Interslide theme

### DIFF
--- a/newsreader/assets/css/interslide-video.css
+++ b/newsreader/assets/css/interslide-video.css
@@ -1,0 +1,26 @@
+:root {
+  --cs-header-background: #000000;
+  --cs-header-submenu-background: #000000;
+  --cs-header-topbar-background: #ff0000;
+  --cs-footer-background: #000000;
+  --cs-offcanvas-background: #000000;
+  --cs-color-accent: #ff0000;
+  --cs-color-button: #ff0000;
+  --cs-color-button-hover: #cc0000;
+  --cs-color-video-icon: #ff0000;
+}
+
+/* Responsive video container */
+.cs-video-container,
+.entry-content .video-container {
+  position: relative;
+  width: 100%;
+}
+.cs-video-container iframe,
+.cs-video-container video,
+.entry-content .video-container iframe,
+.entry-content .video-container video {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16/9;
+}

--- a/newsreader/inc/assets.php
+++ b/newsreader/inc/assets.php
@@ -65,14 +65,18 @@ if ( ! function_exists( 'csco_enqueue_scripts' ) ) {
 		// Register theme styles.
 		wp_register_style( 'csco-styles', csco_style( get_template_directory_uri() . '/style.css' ), array(), $version );
 
-		// Enqueue theme styles.
-		wp_enqueue_style( 'csco-styles' );
+                // Enqueue theme styles.
+                wp_enqueue_style( 'csco-styles' );
 
-		// Add RTL support.
-		wp_style_add_data( 'csco-styles', 'rtl', 'replace' );
+                // Add custom overrides for Interslide.
+                wp_register_style( 'interslide-video', get_template_directory_uri() . '/assets/css/interslide-video.css', array( 'csco-styles' ), $version );
+                wp_enqueue_style( 'interslide-video' );
 
-		// Enqueue typography styles.
-		csco_enqueue_typography_styles( 'csco-styles' );
+                // Add RTL support.
+                wp_style_add_data( 'csco-styles', 'rtl', 'replace' );
+
+                // Enqueue typography styles.
+                csco_enqueue_typography_styles( 'csco-styles' );
 
 		// Dequeue Contact Form 7 styles.
 		wp_dequeue_style( 'contact-form-7' );


### PR DESCRIPTION
## Summary
- Add custom CSS overrides for red/black/white branding and responsive video containers
- Enqueue new stylesheet in theme assets loader

## Testing
- `php -l inc/assets.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a1aac2b8833089edf210cf633f87