### PR TITLE
Display embedded videos in post headers

### DIFF
--- a/newsreader/inc/theme-functions.php
+++ b/newsreader/inc/theme-functions.php
@@ -623,6 +623,33 @@ if ( ! function_exists( 'csco_get_youtube_video_id' ) ) {
 	}
 }
 
+if ( ! function_exists( 'csco_get_post_video' ) ) {
+       /**
+        * Retrieve first embedded video from post content.
+        *
+        * @param int|null $post_id Post ID.
+        * @return string|false Video HTML or false if none found.
+        */
+       function csco_get_post_video( $post_id = null ) {
+               if ( ! $post_id ) {
+                       $post_id = get_the_ID();
+               }
+
+               $content = get_post_field( 'post_content', $post_id );
+               if ( ! $content ) {
+                       return false;
+               }
+
+               $media = get_media_embedded_in_content( apply_filters( 'the_content', $content ), array( 'video', 'object', 'embed', 'iframe' ) );
+
+               if ( ! empty( $media ) ) {
+                       return $media[0];
+               }
+
+               return false;
+       }
+}
+
 if ( ! function_exists( 'csco_get_video_background' ) ) {
 	/**
 	 * Get element video background

--- a/newsreader/style.css
+++ b/newsreader/style.css
@@ -1715,8 +1715,15 @@ table thead td,
 .entry-content iframe,
 .entry-content object,
 .entry-content embed {
-	max-width: 100%;
-	overflow: hidden;
+        max-width: 100%;
+        overflow: hidden;
+}
+
+.cs-entry__video iframe,
+.cs-entry__video video {
+        width: 100%;
+        height: 100%;
+        display: block;
 }
 
 .alignnone {

--- a/newsreader/template-parts/entry/entry-media-large.php
+++ b/newsreader/template-parts/entry/entry-media-large.php
@@ -23,22 +23,28 @@ if ( $media_display ) {
 		<div class="cs-entry__header cs-entry__header-overlay">
 			<div class="cs-entry__media cs-entry__media-large cs-entry__media-overlay cs-video-wrap">
 				<div class="cs-entry__media-inner">
-					<div class="cs-entry__media-wrap cs-overlay-ratio cs-ratio-fullwidth" data-scheme="inverse">
+                                        <div class="cs-entry__media-wrap cs-overlay-ratio cs-ratio-fullwidth" data-scheme="inverse">
+                                                <?php $video = has_post_format( 'video' ) ? csco_get_post_video() : false; ?>
+                                                <?php if ( $video ) : ?>
+                                                        <div class="cs-overlay-background cs-entry__video">
+                                                                <?php echo $video; ?>
+                                                        </div>
+                                                <?php else : ?>
+                                                        <figure class="cs-overlay-background">
+                                                                <?php the_post_thumbnail( $thumbnail_size_mobile ); ?>
+                                                                <?php the_post_thumbnail( $thumbnail_size ); ?>
 
-						<figure class="cs-overlay-background">
-							<?php the_post_thumbnail( $thumbnail_size_mobile ); ?>
-							<?php the_post_thumbnail( $thumbnail_size ); ?>
+                                                                <?php csco_get_video_background( 'large-header', null, 'large', true, true ); ?>
+                                                        </figure>
+                                                <?php endif; ?>
 
-							<?php csco_get_video_background( 'large-header', null, 'large', true, true ); ?>
-						</figure>
+                                                <?php csco_breadcrumbs(); ?>
 
-						<?php csco_breadcrumbs(); ?>
-
-						<div class="cs-entry__media-content">
-							<div class="cs-container">
-								<div class="cs-entry__header-content cs-overlay-content">
-									<div class="cs-entry__header-content-inner">
-										<?php get_template_part( 'template-parts/entry/entry-header-primary-info' ); ?>
+                                                <div class="cs-entry__media-content">
+                                                        <div class="cs-container">
+                                                                <div class="cs-entry__header-content cs-overlay-content">
+                                                                        <div class="cs-entry__header-content-inner">
+                                                                                <?php get_template_part( 'template-parts/entry/entry-header-primary-info' ); ?>
 									</div>
 								</div>
 							</div>

--- a/newsreader/template-parts/entry/entry-media.php
+++ b/newsreader/template-parts/entry/entry-media.php
@@ -12,26 +12,33 @@ $caption = csco_post_thumbnail_caption();
 ?>
 
 <div class="cs-entry__header cs-entry__header-overlay">
-	<div class="cs-entry__outer cs-entry__overlay cs-overlay-ratio cs-ratio-wide cs-video-wrap" data-scheme="inverse">
-		<div class="cs-entry__inner cs-entry__thumbnail">
-			<div class="cs-overlay-background">
-				<?php the_post_thumbnail( $thumbnail_size_mobile ); ?>
-				<?php the_post_thumbnail( $thumbnail_size ); ?>
+       <div class="cs-entry__outer cs-entry__overlay cs-overlay-ratio cs-ratio-wide cs-video-wrap" data-scheme="inverse">
+               <div class="cs-entry__inner cs-entry__thumbnail">
+                       <?php $video = has_post_format( 'video' ) ? csco_get_post_video() : false; ?>
+                       <?php if ( $video ) : ?>
+                               <div class="cs-overlay-background cs-entry__video">
+                                       <?php echo $video; ?>
+                               </div>
+                       <?php else : ?>
+                               <div class="cs-overlay-background">
+                                       <?php the_post_thumbnail( $thumbnail_size_mobile ); ?>
+                                       <?php the_post_thumbnail( $thumbnail_size ); ?>
 
-				<?php
-				if ( 'overlay' === csco_get_page_header_type() ) {
-					csco_get_video_background( 'large-header', null, 'large', true, true );
-				}
-				?>
-			</div>
-		</div>
-		<div class="cs-entry__inner cs-entry__content cs-overlay-content">
-			<?php get_template_part( 'template-parts/entry/entry-header-primary-info' ); ?>
-		</div>
-	</div>
-	<?php if ( $caption ) { ?>
-		<div class="cs-entry__thumbnail-caption">
-			<?php echo esc_attr( $caption ); ?>
-		</div>
-	<?php } ?>
+                                       <?php
+                                       if ( 'overlay' === csco_get_page_header_type() ) {
+                                               csco_get_video_background( 'large-header', null, 'large', true, true );
+                                       }
+                                       ?>
+                               </div>
+                       <?php endif; ?>
+               </div>
+               <div class="cs-entry__inner cs-entry__content cs-overlay-content">
+                       <?php get_template_part( 'template-parts/entry/entry-header-primary-info' ); ?>
+               </div>
+       </div>
+        <?php if ( $caption ) { ?>
+                <div class="cs-entry__thumbnail-caption">
+                        <?php echo esc_attr( $caption ); ?>
+                </div>
+        <?php } ?>
 </div>


### PR DESCRIPTION
## Summary
- Display first embedded video for posts using the video format instead of static thumbnails
- Add helper to retrieve embedded video content
- Ensure embedded videos scale responsively with new CSS

## Testing
- `php -l newsreader/inc/theme-functions.php`
- `php -l newsreader/template-parts/entry/entry-media.php`
- `php -l newsreader/template-parts/entry/entry-media-large.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a1aac2b8833089edf210cf633f87