### PR TITLE
Add configurable video aspect ratio

### DIFF
--- a/newsreader/inc/theme-mods/miscellaneous-settings.php
+++ b/newsreader/inc/theme-mods/miscellaneous-settings.php
@@ -13,13 +13,30 @@ CSCO_Customizer::add_section(
 );
 
 CSCO_Customizer::add_field(
-	array(
-		'type'     => 'checkbox',
-		'settings' => 'misc_published_date',
-		'label'    => esc_html__( 'Display published date instead of modified date', 'newsreader' ),
-		'section'  => 'miscellaneous',
-		'default'  => true,
-	)
+        array(
+                'type'     => 'checkbox',
+                'settings' => 'misc_published_date',
+                'label'    => esc_html__( 'Display published date instead of modified date', 'newsreader' ),
+                'section'  => 'miscellaneous',
+                'default'  => true,
+        )
+);
+
+CSCO_Customizer::add_field(
+       array(
+               'type'     => 'select',
+               'settings' => 'misc_video_aspect_ratio',
+               'label'    => esc_html__( 'Default Video Aspect Ratio', 'newsreader' ),
+               'section'  => 'miscellaneous',
+               'default'  => '16-9',
+               'choices'  => array(
+                       '16-9'   => '16:9',
+                       '9-16'   => '9:16',
+                       '4-3'    => '4:3',
+                       '1-1'    => '1:1',
+                       'per-post' => esc_html__( 'Per Post', 'newsreader' ),
+               ),
+       )
 );
 
 CSCO_Customizer::add_field(

--- a/newsreader/style-rtl.css
+++ b/newsreader/style-rtl.css
@@ -1722,7 +1722,7 @@ table thead td,
 .entry-video-wrapper {
         position: relative;
         width: 100%;
-        padding-top: 56.25%;
+       padding-top: var(--video-aspect-ratio, 56.25%);
         margin-bottom: 1.5rem;
 }
 .entry-video-wrapper iframe,

--- a/newsreader/style.css
+++ b/newsreader/style.css
@@ -1722,7 +1722,7 @@ table thead td,
 .entry-video-wrapper {
         position: relative;
         width: 100%;
-        padding-top: 56.25%;
+       padding-top: var(--video-aspect-ratio, 56.25%);
         margin-bottom: 1.5rem;
 }
 .entry-video-wrapper iframe,

--- a/newsreader/template-parts/content-video.php
+++ b/newsreader/template-parts/content-video.php
@@ -35,10 +35,25 @@
                         array( 'video', 'object', 'embed', 'iframe' )
                 );
 
-                if ( ! empty( $media ) ) {
-                        echo '<div class="entry-video-wrapper">' . $media[0] . '</div>';
+               if ( ! empty( $media ) ) {
 
-                        // Output JSON-LD markup for the embedded video.
+                       $ratio = get_post_meta( get_the_ID(), 'csco_video_aspect_ratio', true );
+                       if ( ! $ratio ) {
+                               $ratio = get_theme_mod( 'misc_video_aspect_ratio', '16-9' );
+                       }
+
+                       $ratios = array(
+                               '16-9' => '56.25%',
+                               '9-16' => '177.77%',
+                               '4-3'  => '75%',
+                               '1-1'  => '100%',
+                       );
+
+                       $padding = isset( $ratios[ $ratio ] ) ? $ratios[ $ratio ] : '56.25%';
+
+                       echo '<div class="entry-video-wrapper" style="--video-aspect-ratio: ' . esc_attr( $padding ) . ';">' . $media[0] . '</div>';
+
+                       // Output JSON-LD markup for the embedded video.
                         if ( preg_match( '/src="([^"]+)"/i', $media[0], $matches ) ) {
                                 $embed_url = $matches[1];
                                 $thumbnail = get_the_post_thumbnail_url( get_the_ID(), 'full' );


### PR DESCRIPTION
## Summary
- allow setting video aspect ratio with CSS variable
- add customizer option to choose default video aspect ratio
- apply aspect ratio variable to embedded videos

## Testing
- `php -l newsreader/template-parts/content-video.php`
- `php -l newsreader/inc/theme-mods/miscellaneous-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ae2c80048330bedecaa4e0753265